### PR TITLE
SMARENG-72 Changed packageId to unsigned integer

### DIFF
--- a/definitions/TagGroup/com.adlinktech.smartpallet/v1.1/PackageTagGroup.json
+++ b/definitions/TagGroup/com.adlinktech.smartpallet/v1.1/PackageTagGroup.json
@@ -10,7 +10,7 @@
          {
             "name": "packageId",
             "description": "The ID of the package",
-            "kind": "STRING",
+            "kind": "UINT32",
             "unit": "n/a"
          },
          {


### PR DESCRIPTION
Following discussion in stand up changed Package Tag Group packageId field to an unsigned integer.